### PR TITLE
init procedure: fix a bug

### DIFF
--- a/src/statsd_client.cpp
+++ b/src/statsd_client.cpp
@@ -99,6 +99,8 @@ int StatsdClient::init()
 
         ret = getaddrinfo(d->host.c_str(), NULL, &hints, &result);
         if ( ret ) {
+            close(d->sock);
+            d->sock = -1;
             snprintf(d->errmsg, sizeof(d->errmsg),
                     "getaddrinfo fail, error=%d, msg=%s", ret, gai_strerror(ret) );
             return -2;


### PR DESCRIPTION
Fix a bug in StatsdClient::init() bad path handling:
close newly opened UDP socket upon init failure.

Prior to this commit, in case statsd-server does not run,
statsd-client would open UDP sockets until the whole application would
crash reaching open file descriptors limit.

Signed-off-by: Andrey Gelman andrey.gelman@gmail.com
